### PR TITLE
rust: Automatically bench all the implementations

### DIFF
--- a/rust/benches/pe_bench.rs
+++ b/rust/benches/pe_bench.rs
@@ -1,18 +1,26 @@
 use criterion::{Criterion, criterion_group, criterion_main};
-use project_euler_rust::solutions::solution_8::{solution_8_functional, solution_8_procedural};
-use std::hint::black_box;
+use project_euler_rust::registry::SolutionEntry;
 
-fn bench_8_procedural(c: &mut Criterion) {
-    c.bench_function("solution_8_procedural", |b| {
-        b.iter(|| solution_8_procedural())
-    });
+fn bench_solutions(c: &mut Criterion) {
+    let mut entries: Vec<&SolutionEntry> = inventory::iter::<SolutionEntry>().collect();
+    entries.sort_by_key(|entry| entry.id);
+
+    for &entry in &entries {
+        let &SolutionEntry {
+            id,
+            implementations,
+            solution: _,
+        } = entry;
+        let mut g = c.benchmark_group(format!("solution for {id}"));
+
+        for &(name, f) in implementations {
+            let name = if name.is_empty() { "solution" } else { name };
+            g.bench_function(name, |b| b.iter(f));
+        }
+
+        g.finish();
+    }
 }
 
-fn bench_8_functional(c: &mut Criterion) {
-    c.bench_function("solution_8_functional", |b| {
-        b.iter(|| solution_8_functional())
-    });
-}
-
-criterion_group!(bench_8, bench_8_procedural, bench_8_functional);
-criterion_main!(bench_8);
+criterion_group!(benches, bench_solutions);
+criterion_main!(benches);


### PR DESCRIPTION
Use grouping to get nice comparisons between implementations of the same solution.

Can run `cargo bench --bench pe_bench -- --quick` for a quick bench, or `cargo bench --bench pe_bench -- 'solution for 8'` to run all the implementations for a solution.